### PR TITLE
feat(#25): 회원 가입 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	/* Redis */
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	/* Email */
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	/* SWAGGER */
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 }

--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.shiftm.shiftm.domain.member.api;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.dto.response.CheckResponse;
 import com.shiftm.shiftm.domain.member.dto.response.MemberResponse;
 import com.shiftm.shiftm.domain.member.service.MemberService;
@@ -31,6 +32,12 @@ public class MemberController {
     @PostMapping("/check/email")
     public void sendEmailVerificationCode(@RequestParam final String email) {
         memberService.sendEmailVerificationCode(email);
+    }
+
+    @GetMapping("/check/email/code")
+    public CheckResponse verifyEmailCode(@Valid @RequestBody final VerifyEmailCodeRequest requestDto) {
+        final boolean isVerified = memberService.verifyEmailCode(requestDto);
+        return new CheckResponse(isVerified);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -28,6 +28,11 @@ public class MemberController {
         return new CheckResponse(isVerified);
     }
 
+    @PostMapping("/check/email")
+    public void sendEmailVerificationCode(@RequestParam final String email) {
+        memberService.sendEmailVerificationCode(email);
+    }
+
     @GetMapping("/me")
     public MemberResponse getProfile(@AuthId final String memberId) {
         final Member member = memberService.getProfile(memberId);

--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.shiftm.shiftm.domain.member.api;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.response.CheckResponse;
 import com.shiftm.shiftm.domain.member.dto.response.MemberResponse;
 import com.shiftm.shiftm.domain.member.service.MemberService;
 import com.shiftm.shiftm.global.auth.annotation.AuthId;
@@ -19,6 +20,12 @@ public class MemberController {
     public MemberResponse signUp(@Valid @RequestBody final SignUpRequest requestDto) {
         final Member member = memberService.signUp(requestDto);
         return new MemberResponse(member);
+    }
+
+    @GetMapping("/check/id")
+    public CheckResponse checkUniqueId(@RequestParam final String id) {
+        final boolean isVerified = memberService.isUniqueId(id);
+        return new CheckResponse(isVerified);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/shiftm/shiftm/domain/member/dto/request/VerifyEmailCodeRequest.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/dto/request/VerifyEmailCodeRequest.java
@@ -1,0 +1,11 @@
+package com.shiftm.shiftm.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VerifyEmailCodeRequest(
+        @NotBlank
+        String email,
+        @NotBlank
+        String verificationCode
+) {
+}

--- a/src/main/java/com/shiftm/shiftm/domain/member/dto/response/CheckResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/dto/response/CheckResponse.java
@@ -1,0 +1,6 @@
+package com.shiftm.shiftm.domain.member.dto.response;
+
+public record CheckResponse(
+        boolean isVerified
+) {
+}

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.shiftm.shiftm.domain.member.service;
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.domain.enums.Role;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedEmailException;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedIdException;
 import com.shiftm.shiftm.domain.member.repository.MemberDao;
@@ -57,6 +58,11 @@ public class MemberService {
 
         final String mailMessage = createMailMessage("ShiftM 이메일 인증 번호", "아래 인증 번호로 이메일 인증을 해주세요.", verificationCode);
         mailSender.sendMail(email, "[ShiftM] 이메일 인증 번호", mailMessage);
+    }
+
+    @Transactional
+    public boolean verifyEmailCode(final VerifyEmailCodeRequest requestDto) {
+        return true;
     }
 
     @Transactional

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
 
     @Transactional
     public boolean isUniqueId(final String id) {
-        return memberRepository.existsById(id);
+        return !memberRepository.existsById(id);
     }
 
     public Member getProfile(final String memberId) {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -62,7 +62,8 @@ public class MemberService {
 
     @Transactional
     public boolean verifyEmailCode(final VerifyEmailCodeRequest requestDto) {
-        return true;
+        final String storedVerificationCode = redisService.getValue("VERIFICATION_CODE:" + requestDto.email());
+        return storedVerificationCode.equals(requestDto.verificationCode());
     }
 
     @Transactional

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
 
     @Transactional
     public boolean isUniqueId(final String id) {
-        return true;
+        return memberRepository.existsById(id);
     }
 
     public Member getProfile(final String memberId) {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -34,6 +34,11 @@ public class MemberService {
         return memberRepository.save(requestDto.toEntity(password, Role.ROLE_USER));
     }
 
+    @Transactional
+    public boolean isUniqueId(final String id) {
+        return true;
+    }
+
     public Member getProfile(final String memberId) {
         return memberDao.findById(memberId);
     }

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -7,16 +7,22 @@ import com.shiftm.shiftm.domain.member.exception.DuplicatedEmailException;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedIdException;
 import com.shiftm.shiftm.domain.member.repository.MemberDao;
 import com.shiftm.shiftm.domain.member.repository.MemberRepository;
+import com.shiftm.shiftm.infra.email.MailSender;
+import com.shiftm.shiftm.infra.redis.RedisService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Random;
 
 @RequiredArgsConstructor
 @Service
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberDao memberDao;
+    private final RedisService redisService;
+    private final MailSender mailSender;
     private final PasswordEncoder passwordEncoder;
 
     // TODO : companyId 유효성 검사 추가
@@ -39,7 +45,60 @@ public class MemberService {
         return !memberRepository.existsById(id);
     }
 
+    @Transactional
+    public void sendEmailVerificationCode(final String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new DuplicatedEmailException(email);
+        }
+
+        final String verificationCode = createVerificationCode();
+
+        redisService.saveValue("VERIFICATION_CODE:" + email, verificationCode, 1000 * 60 * 30);
+
+        final String mailMessage = createMailMessage("ShiftM 이메일 인증 번호", "아래 인증 번호로 이메일 인증을 해주세요.", verificationCode);
+        mailSender.sendMail(email, "[ShiftM] 이메일 인증 번호", mailMessage);
+    }
+
+    @Transactional
     public Member getProfile(final String memberId) {
         return memberDao.findById(memberId);
+    }
+
+    private String createVerificationCode() {
+        final Random random = new Random();
+        final StringBuilder verificationCode = new StringBuilder();
+
+        for (int i = 0; i < 6; i++) {
+            verificationCode.append(random.nextInt(10));
+        }
+
+        return verificationCode.toString();
+    }
+
+    private String createMailMessage(final String title, final String message, final String content) {
+        final StringBuilder mailMessage = new StringBuilder();
+
+        mailMessage.append("<table text-align='center' cellpadding='0' cellspacing='0' width='100%' ");
+        mailMessage.append("style='max-width: 600px; background-color: #FFFFFF; border: 1px solid #DDDDDD; border-radius: 8px; margin: 20px auto; padding: 20px;'>");
+        mailMessage.append("<tr>");
+        mailMessage.append("<td text-align='center' style='padding: 20px;'>");
+        mailMessage.append("<h2 style='color: #333333; margin: 0;'>" + title + "</h2>");
+        mailMessage.append("<p style='color: #666666; font-size: 16px;'>" + message + "</p>");
+        mailMessage.append("</td>");
+        mailMessage.append("</tr>");
+        mailMessage.append("<tr>");
+        mailMessage.append("<td style='text-align: center; padding: 20px 0;'>");
+        mailMessage.append("<span style='display: inline-block; font-size: 24px; color: #333333;'>" + content + "</span>");
+        mailMessage.append("</td>");
+        mailMessage.append("<tr>");
+        mailMessage.append("<td style='padding: 20px; color: #333333; font-size: 16px;'>");
+        mailMessage.append("<p style='margin: 0;'>만약 해당 메일을 요청하지 않았으면 무시해주시기 바랍니다.</p>");
+        mailMessage.append("<p style='margin: 0;'>감사합니다.</p>");
+        mailMessage.append("<p style='margin: 10px 0 0 0;'>Team ShiftM</p>");
+        mailMessage.append("</td>");
+        mailMessage.append("</tr>");
+        mailMessage.append("</table>");
+
+        return mailMessage.toString();
     }
 }

--- a/src/main/java/com/shiftm/shiftm/global/config/EmailConfig.java
+++ b/src/main/java/com/shiftm/shiftm/global/config/EmailConfig.java
@@ -1,0 +1,57 @@
+package com.shiftm.shiftm.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        final JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+
+        properties.put("mail.stmp.auth", auth);
+        properties.put("mail.stmp.starttls.enable", starttlsEnable);
+        properties.put("mail.stmp.starttls.required", starttlsRequired);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/global/config/EmailConfig.java
+++ b/src/main/java/com/shiftm/shiftm/global/config/EmailConfig.java
@@ -48,9 +48,9 @@ public class EmailConfig {
     private Properties getMailProperties() {
         Properties properties = new Properties();
 
-        properties.put("mail.stmp.auth", auth);
-        properties.put("mail.stmp.starttls.enable", starttlsEnable);
-        properties.put("mail.stmp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
 
         return properties;
     }

--- a/src/main/java/com/shiftm/shiftm/global/config/SecurityConfig.java
+++ b/src/main/java/com/shiftm/shiftm/global/config/SecurityConfig.java
@@ -27,6 +27,9 @@ public class SecurityConfig {
 
     private static final String[] whiteList = {
             "/member/signup",
+            "/member/check/id",
+            "/member/check/email",
+            "/member/check/email/code",
             "/auth/login",
             "/auth/reissue"
     };

--- a/src/main/java/com/shiftm/shiftm/global/error/ErrorCode.java
+++ b/src/main/java/com/shiftm/shiftm/global/error/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
 
     /* LEAVE TYPE ERROR */
     DUPLICATED_NAME(400, "LVT001", "It Is Duplicated Name"),
-    NOT_FOUND_LEAVE_TYPE(404, "LVT002", "Leave type not found");
+    NOT_FOUND_LEAVE_TYPE(404, "LVT002", "Leave type not found"),
+
+    /* EMAIL ERROR */
+    UNABLE_TO_SEND_EMAIL(500, "EMAIL001", "Unable To Send Email");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/shiftm/shiftm/infra/email/MailSender.java
+++ b/src/main/java/com/shiftm/shiftm/infra/email/MailSender.java
@@ -1,0 +1,35 @@
+package com.shiftm.shiftm.infra.email;
+
+import com.shiftm.shiftm.infra.email.exception.UnableToSendEmailException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MailSender {
+    private final JavaMailSender javaMailSender;
+
+    public void sendMail(final String to, final String title, final String text) {
+        try {
+            MimeMessage mailMessage = createMailMessage(to, title, text);
+            javaMailSender.send(mailMessage);
+        } catch (Exception e) {
+            throw new UnableToSendEmailException();
+        }
+    }
+
+    private MimeMessage createMailMessage(final String to, final String title, final String text) throws MessagingException {
+        MimeMessage mailMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mailMessage, false, "UTF-8");
+
+        helper.setTo(to);
+        helper.setSubject(title);
+        helper.setText(text);
+
+        return mailMessage;
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/infra/email/MailSender.java
+++ b/src/main/java/com/shiftm/shiftm/infra/email/MailSender.java
@@ -18,7 +18,6 @@ public class MailSender {
             MimeMessage mailMessage = createMailMessage(to, title, text);
             javaMailSender.send(mailMessage);
         } catch (Exception e) {
-            e.printStackTrace();
             throw new UnableToSendEmailException();
         }
     }

--- a/src/main/java/com/shiftm/shiftm/infra/email/MailSender.java
+++ b/src/main/java/com/shiftm/shiftm/infra/email/MailSender.java
@@ -18,6 +18,7 @@ public class MailSender {
             MimeMessage mailMessage = createMailMessage(to, title, text);
             javaMailSender.send(mailMessage);
         } catch (Exception e) {
+            e.printStackTrace();
             throw new UnableToSendEmailException();
         }
     }
@@ -28,7 +29,7 @@ public class MailSender {
 
         helper.setTo(to);
         helper.setSubject(title);
-        helper.setText(text);
+        helper.setText(text, true);
 
         return mailMessage;
     }

--- a/src/main/java/com/shiftm/shiftm/infra/email/exception/UnableToSendEmailException.java
+++ b/src/main/java/com/shiftm/shiftm/infra/email/exception/UnableToSendEmailException.java
@@ -1,0 +1,10 @@
+package com.shiftm.shiftm.infra.email.exception;
+
+import com.shiftm.shiftm.global.error.ErrorCode;
+import com.shiftm.shiftm.global.error.exception.BusinessException;
+
+public class UnableToSendEmailException extends BusinessException {
+    public UnableToSendEmailException() {
+        super(ErrorCode.UNABLE_TO_SEND_EMAIL);
+    }
+}


### PR DESCRIPTION
## ISSUE
FEAT #25 

## Develop
- 아이디 중복 확인 API 구현
- 이메일 인증 번호 전송 API 구현
- 이메일 인증 번호 확인 API 구현

## Test
**API Test**
- 아이디 중복 확인 API

![image](https://github.com/user-attachments/assets/5b56ba2f-611a-4553-84f5-ba79d113cf1a)

- 이메일 인증 번호 전송 API

![image](https://github.com/user-attachments/assets/fb68543d-c9d2-4902-a2aa-a6f7b1bbeedc)

![image](https://github.com/user-attachments/assets/1e5de8d8-c188-49b3-a515-b6aa4a15938d)

- 이메일 인증 번호 확인 API

![image](https://github.com/user-attachments/assets/182269a8-ac78-45d2-9cb8-ad07f3e649df)
