### PR TITLE
feat(#27): 회원 정보 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.shiftm.shiftm.domain.member.api;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
 import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.dto.response.CheckResponse;
 import com.shiftm.shiftm.domain.member.dto.response.MemberResponse;
@@ -43,6 +44,12 @@ public class MemberController {
     @GetMapping("/me")
     public MemberResponse getProfile(@AuthId final String memberId) {
         final Member member = memberService.getProfile(memberId);
+        return new MemberResponse(member);
+    }
+
+    @PatchMapping("/me")
+    public MemberResponse updateProfile(@AuthId final String memberId, @Valid @RequestBody final UpdateRequest requestDto) {
+        final Member member = memberService.updateProfile(memberId, requestDto);
         return new MemberResponse(member);
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -52,4 +52,6 @@ public class MemberController {
         final Member member = memberService.updateProfile(memberId, requestDto);
         return new MemberResponse(member);
     }
+
+
 }

--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.shiftm.shiftm.domain.member.api;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.request.UpdatePasswordRequest;
 import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
 import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.dto.response.CheckResponse;
@@ -53,5 +54,8 @@ public class MemberController {
         return new MemberResponse(member);
     }
 
-
+    @PatchMapping("/me/password")
+    public void updatePassword(@AuthId final String memberId, @Valid @RequestBody final UpdatePasswordRequest requestDto) {
+        memberService.updatePassword(memberId, requestDto);
+    }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/api/MemberController.java
@@ -58,4 +58,9 @@ public class MemberController {
     public void updatePassword(@AuthId final String memberId, @Valid @RequestBody final UpdatePasswordRequest requestDto) {
         memberService.updatePassword(memberId, requestDto);
     }
+
+    @DeleteMapping("/me")
+    public void withdraw(@AuthId final String memberId) {
+        memberService.withdraw(memberId);
+    }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/member/domain/Member.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/domain/Member.java
@@ -40,6 +40,7 @@ public class Member {
     @Column
     private LocalDate entryDate;
 
+    @Setter
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;

--- a/src/main/java/com/shiftm/shiftm/domain/member/domain/Member.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/domain/Member.java
@@ -4,10 +4,7 @@ import com.shiftm.shiftm.domain.member.domain.enums.Gender;
 import com.shiftm.shiftm.domain.member.domain.enums.Role;
 import com.shiftm.shiftm.domain.member.domain.enums.Status;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -22,15 +19,19 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    @Setter
     @Column(nullable = false)
     private String email;
 
+    @Setter
     @Column(nullable = false)
     private String name;
 
+    @Setter
     @Column(nullable = false)
     private LocalDate birthDate;
 
+    @Setter
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/com/shiftm/shiftm/domain/member/domain/Member.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/domain/Member.java
@@ -16,6 +16,7 @@ public class Member {
     @Id
     private String id;
 
+    @Setter
     @Column(nullable = false)
     private String password;
 

--- a/src/main/java/com/shiftm/shiftm/domain/member/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/dto/request/UpdatePasswordRequest.java
@@ -1,0 +1,12 @@
+package com.shiftm.shiftm.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdatePasswordRequest(
+        @NotBlank
+        String currentPassword,
+        @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*()_-]{8,20}")
+        String newPassword
+) {
+}

--- a/src/main/java/com/shiftm/shiftm/domain/member/dto/request/UpdateRequest.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/dto/request/UpdateRequest.java
@@ -1,0 +1,18 @@
+package com.shiftm.shiftm.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record UpdateRequest(
+        @NotBlank
+        String email,
+        @NotBlank
+        String name,
+        @NotNull
+        LocalDate birthDate,
+        @NotBlank
+        String gender
+) {
+}

--- a/src/main/java/com/shiftm/shiftm/domain/member/exception/PasswordNotMatchException.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/exception/PasswordNotMatchException.java
@@ -1,0 +1,10 @@
+package com.shiftm.shiftm.domain.member.exception;
+
+import com.shiftm.shiftm.global.error.ErrorCode;
+import com.shiftm.shiftm.global.error.exception.InvalidValueException;
+
+public class PasswordNotMatchException extends InvalidValueException {
+    public PasswordNotMatchException() {
+        super("password", ErrorCode.PASSWORD_NOT_MATCH);
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.shiftm.shiftm.domain.member.service;
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.domain.enums.Gender;
 import com.shiftm.shiftm.domain.member.domain.enums.Role;
+import com.shiftm.shiftm.domain.member.domain.enums.Status;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
 import com.shiftm.shiftm.domain.member.dto.request.UpdatePasswordRequest;
 import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
@@ -98,8 +99,11 @@ public class MemberService {
         member.setPassword(passwordEncoder.encode(requestDto.newPassword()));
     }
 
+    @Transactional
     public void withdraw(final String memberId) {
+        final Member member = memberDao.findById(memberId);
 
+        member.setStatus(Status.INACTIVE);
     }
 
     private String createVerificationCode() {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -98,6 +98,10 @@ public class MemberService {
         member.setPassword(passwordEncoder.encode(requestDto.newPassword()));
     }
 
+    public void withdraw(final String memberId) {
+
+    }
+
     private String createVerificationCode() {
         final Random random = new Random();
         final StringBuilder verificationCode = new StringBuilder();

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.shiftm.shiftm.domain.member.service;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
+import com.shiftm.shiftm.domain.member.domain.enums.Gender;
 import com.shiftm.shiftm.domain.member.domain.enums.Role;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
 import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
@@ -74,7 +75,14 @@ public class MemberService {
 
     @Transactional
     public Member updateProfile(final String memberId, final UpdateRequest requestDto) {
+        final Member member = memberDao.findById(memberId);
 
+        member.setEmail(requestDto.email());
+        member.setName(requestDto.name());
+        member.setBirthDate(requestDto.birthDate());
+        member.setGender(Gender.valueOf(requestDto.gender()));
+
+        return member;
     }
 
     private String createVerificationCode() {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.domain.enums.Gender;
 import com.shiftm.shiftm.domain.member.domain.enums.Role;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.request.UpdatePasswordRequest;
 import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
 import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedEmailException;
@@ -83,6 +84,10 @@ public class MemberService {
         member.setGender(Gender.valueOf(requestDto.gender()));
 
         return member;
+    }
+
+    public void updatePassword(final String memberId, final UpdatePasswordRequest requestDto) {
+
     }
 
     private String createVerificationCode() {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
 import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedEmailException;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedIdException;
+import com.shiftm.shiftm.domain.member.exception.PasswordNotMatchException;
 import com.shiftm.shiftm.domain.member.repository.MemberDao;
 import com.shiftm.shiftm.domain.member.repository.MemberRepository;
 import com.shiftm.shiftm.infra.email.MailSender;
@@ -86,8 +87,15 @@ public class MemberService {
         return member;
     }
 
+    @Transactional
     public void updatePassword(final String memberId, final UpdatePasswordRequest requestDto) {
+        final Member member = memberDao.findById(memberId);
 
+        if (!requestDto.currentPassword().matches(member.getPassword())) {
+            throw new PasswordNotMatchException();
+        }
+
+        member.setPassword(passwordEncoder.encode(requestDto.newPassword()));
     }
 
     private String createVerificationCode() {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.shiftm.shiftm.domain.member.service;
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.domain.enums.Role;
 import com.shiftm.shiftm.domain.member.dto.request.SignUpRequest;
+import com.shiftm.shiftm.domain.member.dto.request.UpdateRequest;
 import com.shiftm.shiftm.domain.member.dto.request.VerifyEmailCodeRequest;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedEmailException;
 import com.shiftm.shiftm.domain.member.exception.DuplicatedIdException;
@@ -69,6 +70,11 @@ public class MemberService {
     @Transactional
     public Member getProfile(final String memberId) {
         return memberDao.findById(memberId);
+    }
+
+    @Transactional
+    public Member updateProfile(final String memberId, final UpdateRequest requestDto) {
+
     }
 
     private String createVerificationCode() {

--- a/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/member/service/MemberService.java
@@ -83,7 +83,7 @@ public class MemberService {
         member.setEmail(requestDto.email());
         member.setName(requestDto.name());
         member.setBirthDate(requestDto.birthDate());
-        member.setGender(Gender.valueOf(requestDto.gender()));
+        member.setGender(Gender.valueOf(requestDto.gender().toUpperCase()));
 
         return member;
     }
@@ -92,7 +92,7 @@ public class MemberService {
     public void updatePassword(final String memberId, final UpdatePasswordRequest requestDto) {
         final Member member = memberDao.findById(memberId);
 
-        if (!requestDto.currentPassword().matches(member.getPassword())) {
+        if (!passwordEncoder.matches(requestDto.currentPassword(), member.getPassword())) {
             throw new PasswordNotMatchException();
         }
 

--- a/src/main/java/com/shiftm/shiftm/global/error/ErrorCode.java
+++ b/src/main/java/com/shiftm/shiftm/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     DUPLICATED_ID(400, "MEM001", "It Is Duplicated ID"),
     DUPLICATED_EMAIL(400, "MEM002", "It Is Duplicated Email"),
     MEMBER_NOT_FOUND(400, "MEM003", "Member Not Found"),
+    PASSWORD_NOT_MATCH(400, "MEM004", "Password Not Match"),
 
     /* AUTH ERROR */
     INVALID_PASSWORD(400, "AUTH001", "It Is Invalid Password"),


### PR DESCRIPTION
## ISSUE
FEAT #27 

## Develop
- 회원 정보 수정 API 구현
- 비밀번호 수정 API 구현
- 회원 탈퇴 API 구현
- 테스트

## Test
**API Test**
- 회원 정보 수정

![image](https://github.com/user-attachments/assets/ef234d71-a546-41ed-bf47-1e9b8616bfb6)

- 비밀번호 수정

![image](https://github.com/user-attachments/assets/ec72600d-b08c-458f-8a48-48a9e78264f9)

- 회원 탈퇴

![image](https://github.com/user-attachments/assets/a9d0741c-fea7-4cc9-bf78-816d49d76b64)
