### PR TITLE
feat(#29) 관리자용 근무 기록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	/* SWAGGER */
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+
+	/* Excel */
+	implementation 'org.apache.poi:poi-ooxml:5.2.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -34,10 +34,10 @@ public class AdminShiftController {
 
     // 전체 근무 기록 조회
     @GetMapping
-    public AdminShiftListResponse getShifts(@PageableDefault Pageable pageable,
+    public AdminShiftListResponse getShifts(@PageableDefault final Pageable pageable,
                                             @RequestParam(required = false) final String name) {
-        Page<Shift> shiftPage = shiftService.getShifts(pageable, name);
-        List<AdminShiftResponse> shifts = shiftPage.getContent().stream()
+        final Page<Shift> shiftPage = shiftService.getShifts(pageable, name);
+        final List<AdminShiftResponse> shifts = shiftPage.getContent().stream()
                 .map(shift -> new AdminShiftResponse(shift))
                 .collect(Collectors.toList());
         return new AdminShiftListResponse(shifts, shiftPage.getNumber(), shiftPage.getSize(), shiftPage.getTotalPages(), shiftPage.getTotalElements());
@@ -45,12 +45,12 @@ public class AdminShiftController {
 
     // 사후 출근 신청 조회
     @GetMapping("/after-checkin")
-    public AfterCheckinListResponse getAfterCheckin(@PageableDefault Pageable pageable,
+    public AfterCheckinListResponse getAfterCheckin(@PageableDefault final Pageable pageable,
                                                     @RequestParam(required = false) final String name) {
         final Page<Shift> shiftPage = shiftService.getAfterCheckin(pageable, name);
         final List<AdminAfterCheckinResponse> shifts = shiftPage.getContent().stream()
                 .map(shift -> {
-                    String address = geocodingService.getAddress(shift.getCheckin().getLatitude(), shift.getCheckin().getLongitude());
+                    final String address = geocodingService.getAddress(shift.getCheckin().getLatitude(), shift.getCheckin().getLongitude());
                     return new AdminAfterCheckinResponse(shift, address);
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -6,6 +6,7 @@ import com.shiftm.shiftm.domain.shift.dto.request.ShiftStatusRequest;
 import com.shiftm.shiftm.domain.shift.dto.response.*;
 import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
 import com.shiftm.shiftm.domain.shift.service.ShiftService;
+import com.shiftm.shiftm.infra.file.ExcelFileService;
 import com.shiftm.shiftm.infra.geocoding.GeocodingService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,6 +30,7 @@ public class AdminShiftController {
     private final ShiftService shiftService;
     private final ShiftRepository shiftRespository;
     private final GeocodingService geocodingService;
+    private final ExcelFileService excelFileService;
 
     // 전체 근무 기록 조회
     @GetMapping
@@ -74,15 +77,9 @@ public class AdminShiftController {
 
     // 엑셀 파일 변환
     @GetMapping("/export")
-    public void exportShiftRecords(HttpServletResponse response) throws IOException {
+    public void exportShiftRecords(final HttpServletResponse response) {
         final List<Shift> shifts = shiftRespository.findAll();
-        final byte[] excelData = shiftService.exportShiftToExcel(shifts);
-
-        final String encodedFileName = URLEncoder.encode("근무기록.xlsx", "UTF-8").replaceAll("\\+", "%20");
-        response.setHeader("Content-Disposition", "attachment; filename=" + encodedFileName);
-        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-
-        response.getOutputStream().write(excelData);
-        response.flushBuffer();
+        // TODO 근무기록 엑셀 파일 양식 설정
+        excelFileService.generateExcelFile(response, shifts);
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -59,8 +59,9 @@ public class AdminShiftController {
 
     // 출근 상태 변경
     @PatchMapping("/{shiftId}/status")
-    public AfterCheckinResponse updateAfterCheckinStatus(@PathVariable final Long shiftId, @Valid @RequestBody final ShiftStatusRequest requestDto) {
-        return new AfterCheckinResponse(shiftService.updateAfterCheckinStatus(shiftId, requestDto));
+    public AdminAfterCheckinResponse updateAfterCheckinStatus(@PathVariable final Long shiftId, @Valid @RequestBody final ShiftStatusRequest requestDto) {
+        final Shift shift = shiftService.updateAfterCheckinStatus(shiftId, requestDto);
+        return new AdminAfterCheckinResponse(shift, geocodingService.getAddress(shift.getCheckin().getLatitude(), shift.getCheckin().getLongitude()));
     }
 
     // 근무 기록 수정

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -13,14 +13,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,28 +32,24 @@ public class AdminShiftController {
 
     // 전체 근무 기록 조회
     @GetMapping
-    public AdminShiftListResponse getShifts(@RequestParam(defaultValue = "0") final int page,
-                                            @RequestParam(defaultValue = "10") final int size,
+    public AdminShiftListResponse getShifts(@PageableDefault Pageable pageable,
                                             @RequestParam(required = false) final String name) {
-        Pageable pageable = PageRequest.of(page, size);
         Page<Shift> shiftPage = shiftService.getShifts(pageable, name);
         List<AdminShiftResponse> shifts = shiftPage.getContent().stream()
                 .map(shift -> new AdminShiftResponse(shift))
                 .collect(Collectors.toList());
-        return new AdminShiftListResponse(shifts, page, size, shiftPage.getTotalPages(), shiftPage.getTotalElements());
+        return new AdminShiftListResponse(shifts, shiftPage.getNumber(), shiftPage.getSize(), shiftPage.getTotalPages(), shiftPage.getTotalElements());
     }
 
     // 사후 출근 신청 조회
     @GetMapping("/after-checkin")
-    public AfterCheckinListResponse getAfterCheckin(@RequestParam(defaultValue = "0") final int page,
-                                                    @RequestParam(defaultValue = "10") final int size,
+    public AfterCheckinListResponse getAfterCheckin(@PageableDefault Pageable pageable,
                                                     @RequestParam(required = false) final String name) {
-        Pageable pageable = PageRequest.of(page, size);
         Page<Shift> shiftPage = shiftService.getAfterCheckin(pageable, name);
         final List<AfterCheckinResponse> shifts = shiftPage.getContent().stream()
                 .map(shift -> new AfterCheckinResponse(shift))
                 .collect(Collectors.toList());
-        return new AfterCheckinListResponse(shifts, page, size, shiftPage.getTotalPages(), shiftPage.getTotalElements());
+        return new AfterCheckinListResponse(shifts, shiftPage.getNumber(), shiftPage.getSize(), shiftPage.getTotalPages(), shiftPage.getTotalElements());
     }
 
     // 출근 상태 변경

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -1,11 +1,13 @@
 package com.shiftm.shiftm.domain.shift.api;
 
 import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.dto.request.ShiftStatusRequest;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinResponse;
 import com.shiftm.shiftm.domain.shift.service.ShiftService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -46,5 +48,11 @@ public class AdminShiftController {
                 .map(shift -> new AfterCheckinResponse(shift))
                 .collect(Collectors.toList());
         return new AfterCheckinListResponse(shifts, page, size, shiftPage.getTotalPages(), shiftPage.getTotalElements());
+    }
+
+    // 출근 상태 변경
+    @PatchMapping("/{shiftId}/status")
+    public AfterCheckinResponse updateAfterCheckinStatus(@PathVariable final Long shiftId, @Valid @RequestBody final ShiftStatusRequest requestDto) {
+        return new AfterCheckinResponse(shiftService.updateAfterCheckinStatus(shiftId, requestDto));
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,7 +36,7 @@ public class AdminShiftController {
     }
 
     // 사후 출근 신청 조회
-    @GetMapping("/checkin/after")
+    @GetMapping("/after-checkin")
     public AfterCheckinListResponse getAfterCheckin(@RequestParam(defaultValue = "0") final int page,
                                                     @RequestParam(defaultValue = "10") final int size,
                                                     @RequestParam(required = false) final String name) {

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -1,0 +1,38 @@
+package com.shiftm.shiftm.domain.shift.api;
+
+import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftListResponse;
+import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftResponse;
+import com.shiftm.shiftm.domain.shift.service.ShiftService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin/shift")
+@RestController
+public class AdminShiftController {
+
+    private final ShiftService shiftService;
+
+    // 전체 근무 기록 조회
+    @GetMapping
+    public AdminShiftListResponse getShifts(@RequestParam(defaultValue = "0") final int page,
+                                            @RequestParam(defaultValue = "10") final int size,
+                                            @RequestParam(required = false) final String name) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Shift> shiftPage = shiftService.getShifts(pageable, name);
+        List<AdminShiftResponse> shifts = shiftPage.getContent().stream()
+                .map(shift -> new AdminShiftResponse(shift))
+                .collect(Collectors.toList());
+        return new AdminShiftListResponse(shifts, page, size, shiftPage.getTotalPages(), shiftPage.getTotalElements());
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -3,6 +3,8 @@ package com.shiftm.shiftm.domain.shift.api;
 import com.shiftm.shiftm.domain.shift.domain.Shift;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftResponse;
+import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinListResponse;
+import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinResponse;
 import com.shiftm.shiftm.domain.shift.service.ShiftService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,5 +36,18 @@ public class AdminShiftController {
                 .map(shift -> new AdminShiftResponse(shift))
                 .collect(Collectors.toList());
         return new AdminShiftListResponse(shifts, page, size, shiftPage.getTotalPages(), shiftPage.getTotalElements());
+    }
+
+    // 사후 출근 신청 조회
+    @GetMapping("/checkin/after")
+    public AfterCheckinListResponse getAfterCheckin(@RequestParam(defaultValue = "0") final int page,
+                                                    @RequestParam(defaultValue = "10") final int size,
+                                                    @RequestParam(required = false) final String name) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Shift> shiftPage = shiftService.getAfterCheckin(pageable, name);
+        final List<AfterCheckinResponse> shifts = shiftPage.getContent().stream()
+                .map(shift -> new AfterCheckinResponse(shift))
+                .collect(Collectors.toList());
+        return new AfterCheckinListResponse(shifts, page, size, shiftPage.getTotalPages(), shiftPage.getTotalElements());
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -1,6 +1,7 @@
 package com.shiftm.shiftm.domain.shift.api;
 
 import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.dto.request.ShiftRequest;
 import com.shiftm.shiftm.domain.shift.dto.request.ShiftStatusRequest;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftResponse;
@@ -54,5 +55,11 @@ public class AdminShiftController {
     @PatchMapping("/{shiftId}/status")
     public AfterCheckinResponse updateAfterCheckinStatus(@PathVariable final Long shiftId, @Valid @RequestBody final ShiftStatusRequest requestDto) {
         return new AfterCheckinResponse(shiftService.updateAfterCheckinStatus(shiftId, requestDto));
+    }
+
+    // 근무 기록 수정
+    @PatchMapping("/{shiftId}")
+    public AdminShiftResponse updateShift(@PathVariable final Long shiftId, @Valid @RequestBody final ShiftRequest requestDto) {
+        return new AdminShiftResponse(shiftService.updateShift(shiftId, requestDto));
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -7,6 +7,7 @@ import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AdminShiftResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinResponse;
+import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
 import com.shiftm.shiftm.domain.shift.service.ShiftService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 public class AdminShiftController {
 
     private final ShiftService shiftService;
+    private final ShiftRepository shiftRespository;
 
     // 전체 근무 기록 조회
     @GetMapping
@@ -61,5 +63,11 @@ public class AdminShiftController {
     @PatchMapping("/{shiftId}")
     public AdminShiftResponse updateShift(@PathVariable final Long shiftId, @Valid @RequestBody final ShiftRequest requestDto) {
         return new AdminShiftResponse(shiftService.updateShift(shiftId, requestDto));
+    }
+
+    // 근무 기록 삭제
+    @DeleteMapping("/{shiftId}")
+    public void deleteShift(@PathVariable final Long shiftId) {
+        shiftRespository.deleteById(shiftId);
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/AdminShiftController.java
@@ -9,6 +9,7 @@ import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinListResponse;
 import com.shiftm.shiftm.domain.shift.dto.response.AfterCheckinResponse;
 import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
 import com.shiftm.shiftm.domain.shift.service.ShiftService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -69,5 +74,19 @@ public class AdminShiftController {
     @DeleteMapping("/{shiftId}")
     public void deleteShift(@PathVariable final Long shiftId) {
         shiftRespository.deleteById(shiftId);
+    }
+
+    // 엑셀 파일 변환
+    @GetMapping("/export")
+    public void exportShiftRecords(HttpServletResponse response) throws IOException {
+        final List<Shift> shifts = shiftRespository.findAll();
+        final byte[] excelData = shiftService.exportShiftToExcel(shifts);
+
+        final String encodedFileName = URLEncoder.encode("근무기록.xlsx", "UTF-8").replaceAll("\\+", "%20");
+        response.setHeader("Content-Disposition", "attachment; filename=" + encodedFileName);
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+
+        response.getOutputStream().write(excelData);
+        response.flushBuffer();
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/api/ShiftController.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/api/ShiftController.java
@@ -28,7 +28,7 @@ public class ShiftController {
         return new CheckinResponse(shift);
     }
 
-    @PostMapping("/check-in/after")
+    @PostMapping("/after-checkin")
     public AfterCheckinResponse createAfterCheckin(@AuthId final String memberId, @Valid @RequestBody final AfterCheckinRequest requestDto) {
         final Shift shift = shiftService.createAfterCheckin(memberId, requestDto);
         return new AfterCheckinResponse(shift);

--- a/src/main/java/com/shiftm/shiftm/domain/shift/domain/Shift.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/domain/Shift.java
@@ -7,11 +7,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "update shifts set deleted = 1 where id = ?")
 @Table(name = "shifts")
 @Entity
 public class Shift {
@@ -28,6 +30,9 @@ public class Shift {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Column
+    private int deleted = 0; // TODO deletedAt으로 변경 (삭제 시간 저장)
 
     @Builder
     public Shift(final Checkin checkin, final Checkout checkout, final Member member) {

--- a/src/main/java/com/shiftm/shiftm/domain/shift/domain/Shift.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/domain/Shift.java
@@ -43,4 +43,9 @@ public class Shift {
     public void updateStatus(final Status status) {
         this.checkin = new Checkin(checkin.getCheckinTime(), checkin.getLatitude(), checkin.getLongitude(), status);
     }
+
+    public void update(final LocalDateTime checkinTime, final Double latitude, final Double longitude, final Status status, final LocalDateTime checkoutTime) {
+        this.checkin = new Checkin(checkinTime, latitude, longitude, status);
+        this.checkout = new Checkout(checkoutTime);
+    }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/domain/Shift.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/domain/Shift.java
@@ -1,6 +1,7 @@
 package com.shiftm.shiftm.domain.shift.domain;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,5 +38,9 @@ public class Shift {
 
     public void checkout(final LocalDateTime checkoutTime) {
         this.checkout = new Checkout(checkoutTime);
+    }
+
+    public void updateStatus(final Status status) {
+        this.checkin = new Checkin(checkin.getCheckinTime(), checkin.getLatitude(), checkin.getLongitude(), status);
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/request/ShiftRequest.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/request/ShiftRequest.java
@@ -1,0 +1,36 @@
+package com.shiftm.shiftm.domain.shift.dto.request;
+
+import com.shiftm.shiftm.domain.shift.domain.Checkin;
+import com.shiftm.shiftm.domain.shift.domain.Checkout;
+import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record ShiftRequest(
+        @NotNull
+        LocalDateTime checkinTime,
+        @NotNull
+        Double latitude,
+        @NotNull
+        Double longitude,
+        @NotNull
+        Status status,
+        @NotNull
+        LocalDateTime checkoutTime
+) {
+    public Shift toEntity() {
+        return Shift.builder()
+                .checkin(Checkin.builder()
+                        .checkinTime(checkinTime)
+                        .latitude(latitude)
+                        .longitude(longitude)
+                        .status(status)
+                        .build())
+                .checkout(Checkout.builder()
+                        .checkoutTime(checkoutTime)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/request/ShiftStatusRequest.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/request/ShiftStatusRequest.java
@@ -1,0 +1,10 @@
+package com.shiftm.shiftm.domain.shift.dto.request;
+
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
+import jakarta.validation.constraints.NotNull;
+
+public record ShiftStatusRequest(
+        @NotNull
+        Status status
+) {
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AdminAfterCheckinResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AdminAfterCheckinResponse.java
@@ -1,0 +1,18 @@
+package com.shiftm.shiftm.domain.shift.dto.response;
+
+import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
+
+import java.time.LocalDateTime;
+
+public record AdminAfterCheckinResponse(
+        Long id,
+        String name,
+        String address,
+        LocalDateTime checkinTime,
+        Status status
+) {
+    public AdminAfterCheckinResponse(final Shift shift, final String address) {
+        this(shift.getId(), shift.getMember().getName(), address, shift.getCheckin().getCheckinTime(), shift.getCheckin().getStatus());
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AdminShiftListResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AdminShiftListResponse.java
@@ -1,0 +1,20 @@
+package com.shiftm.shiftm.domain.shift.dto.response;
+
+import java.util.List;
+
+public record AdminShiftListResponse(
+    List<AdminShiftResponse> content,
+    int page,
+    int size,
+    int totalPages,
+    Long totalElements
+) {
+    public AdminShiftListResponse(final List<AdminShiftResponse> content,
+                                  final int page, final int size, final int totalPages, final Long totalElements) {
+        this.content = List.copyOf(content);
+        this.page = page;
+        this.size = size;
+        this.totalPages = totalPages;
+        this.totalElements = totalElements;
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AdminShiftResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AdminShiftResponse.java
@@ -1,0 +1,20 @@
+package com.shiftm.shiftm.domain.shift.dto.response;
+
+import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
+
+import java.time.LocalDateTime;
+
+public record AdminShiftResponse(
+        Long id,
+        LocalDateTime checkinTime,
+        Double latitude,
+        Double longitude,
+        Status status,
+        LocalDateTime checkoutTime
+) {
+    public AdminShiftResponse(final Shift shift) {
+        this(shift.getId(), shift.getCheckin().getCheckinTime(), shift.getCheckin().getLatitude(), shift.getCheckin().getLongitude(),
+                shift.getCheckin().getStatus(), shift.getCheckout() != null ? shift.getCheckout().getCheckoutTime() : null);
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinListResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinListResponse.java
@@ -3,13 +3,13 @@ package com.shiftm.shiftm.domain.shift.dto.response;
 import java.util.List;
 
 public record AfterCheckinListResponse(
-    List<AfterCheckinResponse> content,
+    List<AdminAfterCheckinResponse> content,
     int page,
     int size,
     int totalPages,
     Long totalElements
 ) {
-    public AfterCheckinListResponse(final List<AfterCheckinResponse> content,
+    public AfterCheckinListResponse(final List<AdminAfterCheckinResponse> content,
                                     final int page, final int size, final int totalPages, final Long totalElements) {
         this.content = List.copyOf(content);
         this.page = page;

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinListResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinListResponse.java
@@ -1,0 +1,20 @@
+package com.shiftm.shiftm.domain.shift.dto.response;
+
+import java.util.List;
+
+public record AfterCheckinListResponse(
+    List<AfterCheckinResponse> content,
+    int page,
+    int size,
+    int totalPages,
+    Long totalElements
+) {
+    public AfterCheckinListResponse(final List<AfterCheckinResponse> content,
+                                    final int page, final int size, final int totalPages, final Long totalElements) {
+        this.content = List.copyOf(content);
+        this.page = page;
+        this.size = size;
+        this.totalPages = totalPages;
+        this.totalElements = totalElements;
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinResponse.java
@@ -5,7 +5,7 @@ import com.shiftm.shiftm.domain.shift.domain.enums.Status;
 
 import java.time.LocalDateTime;
 
-public record AfterCheckinResponse (
+public record AfterCheckinResponse(
         Long id,
         LocalDateTime checkinTime,
         Double latitude,

--- a/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinResponse.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/dto/response/AfterCheckinResponse.java
@@ -1,6 +1,7 @@
 package com.shiftm.shiftm.domain.shift.dto.response;
 
 import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
 
 import java.time.LocalDateTime;
 
@@ -8,10 +9,11 @@ public record AfterCheckinResponse (
         Long id,
         LocalDateTime checkinTime,
         Double latitude,
-        Double longitude
+        Double longitude,
+        Status status
 ) {
     public AfterCheckinResponse(final Shift shift) {
-        this(shift.getId(), shift.getCheckin().getCheckinTime(),
-                shift.getCheckin().getLatitude(), shift.getCheckin().getLongitude());
+        this(shift.getId(), shift.getCheckin().getCheckinTime(), shift.getCheckin().getLatitude(),
+                shift.getCheckin().getLongitude(), shift.getCheckin().getStatus());
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
@@ -2,6 +2,8 @@ package com.shiftm.shiftm.domain.shift.repository;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.shift.domain.Shift;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -22,4 +24,7 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             "AND (:start IS NULL OR s.checkin.checkinTime >= :start) " +
             "AND (:end IS NULL OR s.checkin.checkinTime <= :end)")
     List<Shift> findShiftsByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT s FROM Shift s WHERE s.member.name = :name")
+    Page<Shift> findByName(final Pageable pageable, final String name);
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
@@ -16,17 +16,17 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
 
     @Query("SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END FROM Shift s " +
             "WHERE s.member = :member AND s.checkin.checkinTime >= :start AND s.checkin.checkinTime <= :end")
-    boolean existsByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
+    boolean existsByMemberAndCheckinTimeInRange(final Member member, final LocalDateTime start, final LocalDateTime end);
 
     @Query("SELECT s FROM Shift s WHERE s.member = :member AND s.checkin.checkinTime >= :start AND s.checkin.checkinTime <= :end " +
             "AND s.deleted = 0")
-    Optional<Shift> findShiftByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
+    Optional<Shift> findShiftByMemberAndCheckinTimeInRange(final Member member, final LocalDateTime start, final LocalDateTime end);
 
     @Query("SELECT s FROM Shift s WHERE s.member = :member " +
             "AND (:start IS NULL OR s.checkin.checkinTime >= :start) " +
             "AND (:end IS NULL OR s.checkin.checkinTime <= :end) " +
             "AND s.deleted = 0")
-    List<Shift> findShiftsByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
+    List<Shift> findShiftsByMemberAndCheckinTimeInRange(final Member member, final LocalDateTime start, final LocalDateTime end);
 
     @Query("SELECT s FROM Shift s WHERE s.member.name = :name")
     Page<Shift> findByName(final Pageable pageable, final String name);

--- a/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
@@ -18,12 +18,14 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             "WHERE s.member = :member AND s.checkin.checkinTime >= :start AND s.checkin.checkinTime <= :end")
     boolean existsByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
 
-    @Query("SELECT s FROM Shift s WHERE s.member = :member AND s.checkin.checkinTime >= :start AND s.checkin.checkinTime <= :end")
+    @Query("SELECT s FROM Shift s WHERE s.member = :member AND s.checkin.checkinTime >= :start AND s.checkin.checkinTime <= :end " +
+            "AND s.deleted = 0")
     Optional<Shift> findShiftByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
 
     @Query("SELECT s FROM Shift s WHERE s.member = :member " +
             "AND (:start IS NULL OR s.checkin.checkinTime >= :start) " +
-            "AND (:end IS NULL OR s.checkin.checkinTime <= :end)")
+            "AND (:end IS NULL OR s.checkin.checkinTime <= :end) " +
+            "AND s.deleted = 0")
     List<Shift> findShiftsByMemberAndCheckinTimeInRange(Member member, LocalDateTime start, LocalDateTime end);
 
     @Query("SELECT s FROM Shift s WHERE s.member.name = :name")

--- a/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/repository/ShiftRepository.java
@@ -2,6 +2,7 @@ package com.shiftm.shiftm.domain.shift.repository;
 
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +28,20 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
 
     @Query("SELECT s FROM Shift s WHERE s.member.name = :name")
     Page<Shift> findByName(final Pageable pageable, final String name);
+
+    @Query("SELECT s FROM Shift s WHERE s.checkin.status != :status " +
+            "ORDER BY CASE " +
+            "WHEN s.checkin.status = 'PENDING' THEN 1 " +
+            "WHEN s.checkin.status = 'APPROVED' THEN 2 " +
+            "WHEN s.checkin.status = 'REJECTED' THEN 3 " +
+            "ELSE 4 END")
+    Page<Shift> findByStatusExcludeOrdered(final Pageable pageable, final Status status);
+
+    @Query("SELECT s FROM Shift s WHERE s.checkin.status != :status AND s.member.name = :name " +
+            "ORDER BY CASE " +
+            "WHEN s.checkin.status = 'PENDING' THEN 1 " +
+            "WHEN s.checkin.status = 'APPROVED' THEN 2 " +
+            "WHEN s.checkin.status = 'REJECTED' THEN 3 " +
+            "ELSE 4 END")
+    Page<Shift> findByStatusExcludeAndNameOrdered(final Pageable pageable, final Status status, final String name);
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
@@ -4,10 +4,7 @@ import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.repository.MemberDao;
 import com.shiftm.shiftm.domain.shift.domain.Shift;
 import com.shiftm.shiftm.domain.shift.domain.enums.Status;
-import com.shiftm.shiftm.domain.shift.dto.request.AfterCheckinRequest;
-import com.shiftm.shiftm.domain.shift.dto.request.CheckinRequest;
-import com.shiftm.shiftm.domain.shift.dto.request.CheckoutRequest;
-import com.shiftm.shiftm.domain.shift.dto.request.ShiftStatusRequest;
+import com.shiftm.shiftm.domain.shift.dto.request.*;
 import com.shiftm.shiftm.domain.shift.exception.CheckinAlreadyExistsException;
 import com.shiftm.shiftm.domain.shift.exception.ShiftNotFoundException;
 import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
@@ -95,6 +92,14 @@ public class ShiftService {
     public Shift updateAfterCheckinStatus(final Long shiftId, final ShiftStatusRequest requestDto) {
         final Shift shift = findById(shiftId);
         shift.updateStatus(requestDto.status());
+        return shift;
+    }
+
+    @Transactional
+    public Shift updateShift(final Long shiftId, final ShiftRequest requestDto) {
+        final Shift shift = findById(shiftId);
+        shift.update(requestDto.checkinTime(), requestDto.latitude(),
+                requestDto.longitude(), requestDto.status(), requestDto.checkoutTime());
         return shift;
     }
 

--- a/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
@@ -8,6 +8,7 @@ import com.shiftm.shiftm.domain.shift.dto.request.*;
 import com.shiftm.shiftm.domain.shift.exception.CheckinAlreadyExistsException;
 import com.shiftm.shiftm.domain.shift.exception.ShiftNotFoundException;
 import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
+import com.shiftm.shiftm.infra.geocoding.GeocodingService;
 import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -32,6 +33,7 @@ public class ShiftService {
     private static final LocalTime PIVOT_TIME = LocalTime.of(4, 0);
 
     private final ShiftRepository shiftRepository;
+    private final GeocodingService geocodingService;
     private final MemberDao memberDao;
 
     @Transactional

--- a/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
@@ -7,6 +7,7 @@ import com.shiftm.shiftm.domain.shift.domain.enums.Status;
 import com.shiftm.shiftm.domain.shift.dto.request.AfterCheckinRequest;
 import com.shiftm.shiftm.domain.shift.dto.request.CheckinRequest;
 import com.shiftm.shiftm.domain.shift.dto.request.CheckoutRequest;
+import com.shiftm.shiftm.domain.shift.dto.request.ShiftStatusRequest;
 import com.shiftm.shiftm.domain.shift.exception.CheckinAlreadyExistsException;
 import com.shiftm.shiftm.domain.shift.exception.ShiftNotFoundException;
 import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
@@ -91,11 +92,22 @@ public class ShiftService {
         return shiftRepository.findByStatusExcludeAndNameOrdered(pageable, Status.AUTO_APPROVED, name);
     }
 
+    public Shift updateAfterCheckinStatus(final Long shiftId, final ShiftStatusRequest requestDto) {
+        final Shift shift = findById(shiftId);
+        shift.updateStatus(requestDto.status());
+        return shift;
+    }
+
     private void validateDuplicateCheckin(final Member member) {
         final LocalDateTime start = LocalDate.now().atStartOfDay();
         final LocalDateTime end = start.plusDays(1).minusNanos(1);
         if (shiftRepository.existsByMemberAndCheckinTimeInRange(member, start, end)) {
             throw new CheckinAlreadyExistsException();
         }
+    }
+
+    private Shift findById(final Long shiftId) {
+        return shiftRepository.findById(shiftId)
+                .orElseThrow(() -> new ShiftNotFoundException());
     }
 }

--- a/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
@@ -3,6 +3,7 @@ package com.shiftm.shiftm.domain.shift.service;
 import com.shiftm.shiftm.domain.member.domain.Member;
 import com.shiftm.shiftm.domain.member.repository.MemberDao;
 import com.shiftm.shiftm.domain.shift.domain.Shift;
+import com.shiftm.shiftm.domain.shift.domain.enums.Status;
 import com.shiftm.shiftm.domain.shift.dto.request.AfterCheckinRequest;
 import com.shiftm.shiftm.domain.shift.dto.request.CheckinRequest;
 import com.shiftm.shiftm.domain.shift.dto.request.CheckoutRequest;
@@ -80,6 +81,14 @@ public class ShiftService {
             return shiftRepository.findAll(pageable);
         }
         return shiftRepository.findByName(pageable, name);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Shift> getAfterCheckin(final Pageable pageable, final String name) {
+        if (name == null || name.isEmpty()) {
+            return shiftRepository.findByStatusExcludeOrdered(pageable, Status.AUTO_APPROVED);
+        }
+        return shiftRepository.findByStatusExcludeAndNameOrdered(pageable, Status.AUTO_APPROVED, name);
     }
 
     private void validateDuplicateCheckin(final Member member) {

--- a/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
@@ -111,30 +111,6 @@ public class ShiftService {
         return shift;
     }
 
-    public byte[] exportShiftToExcel(List<Shift> shifts) throws IOException {
-        final Workbook workbook = new XSSFWorkbook();
-        final Sheet sheet = workbook.createSheet("근무 기록");
-
-        final Row headerRow = sheet.createRow(0);
-        headerRow.createCell(0).setCellValue("사원명");
-        headerRow.createCell(1).setCellValue("출근 시간");
-        headerRow.createCell(2).setCellValue("퇴근 시간");
-
-        int rowNum = 1;
-        for (Shift shift : shifts) {
-            Row row = sheet.createRow(rowNum++);
-            row.createCell(0).setCellValue(shift.getMember().getName());
-            row.createCell(1).setCellValue(shift.getCheckin().getCheckinTime().toString());
-            row.createCell(2).setCellValue(shift.getCheckout().getCheckoutTime().toString());
-        }
-
-        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        workbook.write(byteArrayOutputStream);
-        workbook.close();
-
-        return byteArrayOutputStream.toByteArray();
-    }
-
     private void validateDuplicateCheckin(final Member member) {
         final LocalDateTime start = LocalDate.now().atStartOfDay();
         final LocalDateTime end = start.plusDays(1).minusNanos(1);

--- a/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftm/shiftm/domain/shift/service/ShiftService.java
@@ -10,6 +10,8 @@ import com.shiftm.shiftm.domain.shift.exception.CheckinAlreadyExistsException;
 import com.shiftm.shiftm.domain.shift.exception.ShiftNotFoundException;
 import com.shiftm.shiftm.domain.shift.repository.ShiftRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,6 +72,14 @@ public class ShiftService {
         final Shift shift = shiftRepository.findShiftByMemberAndCheckinTimeInRange(member, start, end)
                 .orElseThrow(() -> new ShiftNotFoundException());
         return shift;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Shift> getShifts(final Pageable pageable, final String name) {
+        if (name == null || name.isEmpty()) {
+            return shiftRepository.findAll(pageable);
+        }
+        return shiftRepository.findByName(pageable, name);
     }
 
     private void validateDuplicateCheckin(final Member member) {

--- a/src/main/java/com/shiftm/shiftm/infra/file/ExcelFileService.java
+++ b/src/main/java/com/shiftm/shiftm/infra/file/ExcelFileService.java
@@ -1,0 +1,57 @@
+package com.shiftm.shiftm.infra.file;
+
+import com.shiftm.shiftm.domain.shift.domain.Shift;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+public class ExcelFileService {
+
+    public void generateExcelFile(final HttpServletResponse response, final List<Shift> shifts) {
+        final Workbook workbook = new XSSFWorkbook();
+        try {
+            final Sheet sheet = workbook.createSheet("Shifts");
+
+            final Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("사원명");
+            headerRow.createCell(1).setCellValue("출근 시간");
+            headerRow.createCell(2).setCellValue("퇴근 시간");
+
+            int rowNum = 1;
+            for (final Shift shift : shifts) {
+                Row row = sheet.createRow(rowNum++);
+                row.createCell(0).setCellValue(shift.getMember().getName());
+                row.createCell(1).setCellValue(shift.getCheckin().getCheckinTime().toString());
+                row.createCell(2).setCellValue(shift.getCheckout() != null ? shift.getCheckout().getCheckoutTime().toString() : "미제출");
+            }
+
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=\"shifts.xlsx\"");
+
+            workbook.write(response.getOutputStream());
+        } catch (IOException e) {
+            log.error("Error occurred while generating the Excel file", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            try {
+                response.getWriter().write("Error occurred while generating the file.");
+            } catch (IOException innerException) {
+                log.error("Error occurred while writing the error message", innerException);
+            }
+        } finally {
+            try {
+                workbook.close();
+            } catch (IOException e) {
+                log.error("Error occurred while closing the workbook", e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/shiftm/shiftm/infra/geocoding/GeocodingResponse.java
+++ b/src/main/java/com/shiftm/shiftm/infra/geocoding/GeocodingResponse.java
@@ -1,0 +1,10 @@
+package com.shiftm.shiftm.infra.geocoding;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record GeocodingResponse(List<Document> documents) {
+    public record Document(@JsonProperty("address") Address address) {}
+    public record Address(@JsonProperty("address_name") String addressName) {}
+}
+

--- a/src/main/java/com/shiftm/shiftm/infra/geocoding/GeocodingService.java
+++ b/src/main/java/com/shiftm/shiftm/infra/geocoding/GeocodingService.java
@@ -26,7 +26,7 @@ public class GeocodingService {
         this.objectMapper = objectMapper;
     }
 
-    public String getAddress(double latitude, double longitude) {
+    public String getAddress(final double latitude, final double longitude) {
         final HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "KakaoAK " + kakaoApiKey);
         final HttpEntity<String> entity = new HttpEntity<>(headers);
@@ -35,7 +35,7 @@ public class GeocodingService {
         try {
             final GeocodingResponse geocodingResponse = objectMapper.readValue(response, GeocodingResponse.class);
             if (geocodingResponse.documents() != null && !geocodingResponse.documents().isEmpty()) {
-                String address = geocodingResponse.documents().get(0).address().addressName();
+                final String address = geocodingResponse.documents().get(0).address().addressName();
                 return address;
             }
         } catch (Exception e) {

--- a/src/main/java/com/shiftm/shiftm/infra/geocoding/GeocodingService.java
+++ b/src/main/java/com/shiftm/shiftm/infra/geocoding/GeocodingService.java
@@ -1,0 +1,47 @@
+package com.shiftm.shiftm.infra.geocoding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GeocodingService {
+
+    @Value("${kakao.api.key}")
+    private String kakaoApiKey;
+
+    private static final String GEOCODING_API_URL = "https://dapi.kakao.com/v2/local/geo/coord2address.json?x={longitude}&y={latitude}";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public GeocodingService(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.objectMapper = objectMapper;
+    }
+
+    public String getAddress(double latitude, double longitude) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+        final HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        final String response = restTemplate.exchange(GEOCODING_API_URL, HttpMethod.GET, entity, String.class, longitude, latitude).getBody();
+        try {
+            final GeocodingResponse geocodingResponse = objectMapper.readValue(response, GeocodingResponse.class);
+            if (geocodingResponse.documents() != null && !geocodingResponse.documents().isEmpty()) {
+                String address = geocodingResponse.documents().get(0).address().addressName();
+                return address;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "주소 변환 실패";
+        }
+        return "주소를 찾을 수 없습니다";
+    }
+}


### PR DESCRIPTION
## ISSUE
- #29 

## Develop
- 전체 근무 기록 조회 API 구현
- 사후 출근 신청 조회 API 구현
- 출근 상태 변경 API 구현
- 근무 기록 수정 API 구현
- 근무 기록 삭제 API 구현

## Test
**전체 근무 기록 조회 API**
![image](https://github.com/user-attachments/assets/3fae5873-4079-4bbb-a725-625c43f7652b)

**사후 출근 신청 조회 API**
![image](https://github.com/user-attachments/assets/02a40382-c259-4aad-869b-9c6389541b65)

**출근 상태 변경 API**
![image](https://github.com/user-attachments/assets/745fca5f-b6e3-41ae-a541-5d5d157f6b47)

**근무 기록 수정 API**
![image](https://github.com/user-attachments/assets/f2bf4d08-d983-4a37-9022-879e6a85454d)

**근무 기록 삭제 API**
![image](https://github.com/user-attachments/assets/b6e56ecc-d51f-4ba2-a3fb-c35c9beb82ec)

