### PR TITLE
setting(#38): Swagger URL에 대한 인증 예외 설정

### DIFF
--- a/src/main/java/com/shiftm/shiftm/global/config/SecurityConfig.java
+++ b/src/main/java/com/shiftm/shiftm/global/config/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
             "/member/find/id",
             "/member/find/password",
             "/auth/login",
-            "/auth/reissue"
+            "/auth/reissue",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
     };
 
     @Bean


### PR DESCRIPTION
## ISSUE
- #38 

## Develop
### Swagger URL에 대한 인증 예외 설정
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/801fbdc2-7ffa-4ad6-b980-c2d5ec84a877" />



## 추가 사항

1. Swagger URL
- http://localhost:8080/swagger-ui/index.html#


2. 인증이 필요한 API 접근 시 파라미터로 로그인한 사용자 아이디 넣어주기 
<img width="568" alt="image" src="https://github.com/user-attachments/assets/054ec85b-8b38-4aaa-887f-ff119f4e159b" />

- 인증이 필요한 `API`인 경우 스웨거에서 `파라미터` 값으로 로그인한 사용자의 아이디를 받습니다.
- @Target 어노테이션 옵션 중 파라미터 값으로 설정했기 때문에 스웨거에서 API 테스트할 때 파라미터로 사용자 아이디 넣어주시면 됩니다!
```java
@Retention(RetentionPolicy.RUNTIME)
@Target(ElementType.PARAMETER)
public @interface AuthId {
}
```

3. Jwt 토큰 헤더에 넣어주기![image](https://github.com/user-attachments/assets/a583c16d-7d50-431d-af11-697bb7e08377)
- Bearer 생략하고 토큰 값만 넣어주시면 됩니다!